### PR TITLE
Refactor data models and update TickAggregator

### DIFF
--- a/kiteconnect/src/com/zerodhatech/models/OHLC.java
+++ b/kiteconnect/src/com/zerodhatech/models/OHLC.java
@@ -8,11 +8,53 @@ import com.google.gson.annotations.SerializedName;
 public class OHLC {
 
     @SerializedName("high")
-    public double high;
+    private double high;
     @SerializedName("low")
-    public double low;
+    private double low;
     @SerializedName("close")
-    public double close;
+    private double close;
     @SerializedName("open")
-    public double open;
+    private double open;
+
+    public OHLC() {
+    }
+
+    public OHLC(OHLC other) {
+        this.open = other.getOpen();
+        this.high = other.getHigh();
+        this.low = other.getLow();
+        this.close = other.getClose();
+    }
+
+    public double getHigh() {
+        return high;
+    }
+
+    public void setHigh(double high) {
+        this.high = high;
+    }
+
+    public double getLow() {
+        return low;
+    }
+
+    public void setLow(double low) {
+        this.low = low;
+    }
+
+    public double getClose() {
+        return close;
+    }
+
+    public void setClose(double close) {
+        this.close = close;
+    }
+
+    public double getOpen() {
+        return open;
+    }
+
+    public void setOpen(double open) {
+        this.open = open;
+    }
 }

--- a/kiteconnect/src/com/zerodhatech/models/Tick.java
+++ b/kiteconnect/src/com/zerodhatech/models/Tick.java
@@ -28,8 +28,8 @@ public class Tick {
     private double change;
     @SerializedName("lastTradeQuantity")
     private double lastTradedQuantity;
-    @SerializedName("averageTradePrice")
-    private double averageTradePrice;
+    @SerializedName("averagePrice") // Renamed from averageTradePrice
+    private double averagePrice;
     @SerializedName("volumeTradedToday")
     private long volumeTradedToday;
     @SerializedName("totalBuyQuantity")
@@ -52,6 +52,21 @@ public class Tick {
     // New field for symbol
     private String symbol;
 
+    // OHLC data
+    private OHLC ohlc;
+
+    // Best Bid/Ask data
+    private double bestBidPrice;
+    private double bestAskPrice;
+    private long bestBidQuantity;
+    private long bestAskQuantity;
+
+    public static enum Mode {
+        LTP,
+        QUOTE,
+        FULL
+    }
+
     // Getters and setters
     public String getSymbol() {
         return symbol;
@@ -59,6 +74,46 @@ public class Tick {
 
     public void setSymbol(String symbol) {
         this.symbol = symbol;
+    }
+
+    public OHLC getOhlc() {
+        return ohlc;
+    }
+
+    public void setOhlc(OHLC ohlc) {
+        this.ohlc = ohlc;
+    }
+
+    public double getBestBidPrice() {
+        return bestBidPrice;
+    }
+
+    public void setBestBidPrice(double bestBidPrice) {
+        this.bestBidPrice = bestBidPrice;
+    }
+
+    public double getBestAskPrice() {
+        return bestAskPrice;
+    }
+
+    public void setBestAskPrice(double bestAskPrice) {
+        this.bestAskPrice = bestAskPrice;
+    }
+
+    public long getBestBidQuantity() {
+        return bestBidQuantity;
+    }
+
+    public void setBestBidQuantity(long bestBidQuantity) {
+        this.bestBidQuantity = bestBidQuantity;
+    }
+
+    public long getBestAskQuantity() {
+        return bestAskQuantity;
+    }
+
+    public void setBestAskQuantity(long bestAskQuantity) {
+        this.bestAskQuantity = bestAskQuantity;
     }
 
     public Date getLastTradedTime() {
@@ -181,12 +236,12 @@ public class Tick {
         this.lastTradedQuantity = lastTradedQuantity;
     }
 
-    public double getAverageTradePrice() {
-        return averageTradePrice;
+    public double getAveragePrice() { // Renamed from getAverageTradePrice
+        return averagePrice;
     }
 
-    public void setAverageTradePrice(double averageTradePrice) {
-        this.averageTradePrice = averageTradePrice;
+    public void setAveragePrice(double averagePrice) { // Renamed from setAverageTradePrice
+        this.averagePrice = averagePrice;
     }
 
     public long getVolumeTradedToday() {


### PR DESCRIPTION
This commit addresses discrepancies between custom data models (Tick, OHLC, Depth) and their usage within TickAggregator.

Key changes:

1.  **Tick.java:**
    *   Added a static `Mode` enum (LTP, QUOTE, FULL).
    *   Renamed `averageTradePrice` to `averagePrice` (including getters/setters and @SerializedName).
    *   Added an `ohlc` field with associated `getOhlc()` and `setOhlc()` methods.
    *   Added fields for `bestBidPrice`, `bestAskPrice`, `bestBidQuantity`, `bestAskQuantity` with corresponding getters and setters.

2.  **OHLC.java:**
    *   Fields (open, high, low, close) are now private with public getters/setters.
    *   Added a copy constructor `OHLC(OHLC other)`.
    *   Ensured a default constructor is present.

3.  **TickAggregator.java:**
    *   Defined a private static inner class `Quote` to replace the previous expectation of `Depth.Quote`. This new class holds price and quantity for market depth levels.
    *   Updated `processMarketDepth` and related field declarations (`currentBidDepthLevels`, `currentAskDepthLevels`) to use the new inner class `Quote` instead of `Depth.Quote`.

These changes align the data models with their usage in the application logic, resolving potential errors and improving code clarity and robustness.