### PR TITLE
Implement Opening Market Trend Analysis and Strategy Adjustment

### DIFF
--- a/kiteconnect/src/com/ibkr/AppContext.java
+++ b/kiteconnect/src/com/ibkr/AppContext.java
@@ -80,6 +80,9 @@ public class AppContext {
     private final int twsPort;
     private final int twsClientId;
 
+    // Market Sentiment Analyzer Config
+    private final int openingObservationMinutes;
+
     public AppContext() {
         // Configuration Data
         Properties properties = new Properties();
@@ -111,13 +114,30 @@ public class AppContext {
         this.twsClientId = tempClientId;
         logger.info("Loaded TWS connection params: Host={}, Port={}, ClientId={}", this.twsHost, this.twsPort, this.twsClientId);
 
+        int tempOpeningObservationMinutes;
+        try {
+            tempOpeningObservationMinutes = Integer.parseInt(properties.getProperty("market.opening.observation.minutes", "15"));
+        } catch (NumberFormatException e) {
+            logger.error("Invalid format for 'market.opening.observation.minutes' in app.properties. Using default 15.", e);
+            tempOpeningObservationMinutes = 15;
+        }
+        this.openingObservationMinutes = tempOpeningObservationMinutes;
+        logger.info("Loaded Market Opening Observation Minutes: {}", this.openingObservationMinutes);
+
+        LocalTime actualMarketOpenTime = LocalTime.of(9, 30); // Default ET market open
+
         this.top100USStocks = loadTop100USStocks(properties); // Pass loaded properties
         Map<String, List<String>> sectorToStocksMap = loadSectorToStocksMap(properties); // Pass loaded properties
         Map<String, String> symbolToSectorMap = loadSymbolToSectorMap(sectorToStocksMap); // Pass the loaded map
 
         // Level 0: No dependencies or only external config
         this.instrumentRegistry = new InstrumentRegistry(this);
-        this.marketSentimentAnalyzer = new MarketSentimentAnalyzer(this, this.top100USStocks); // Pass AppContext
+        this.marketSentimentAnalyzer = new MarketSentimentAnalyzer(
+            this,
+            this.top100USStocks,
+            this.openingObservationMinutes,
+            actualMarketOpenTime
+        );
         // Ensure SectorStrengthAnalyzer gets valid, though possibly empty, maps
         this.sectorStrengthAnalyzer = new SectorStrengthAnalyzer(
             sectorToStocksMap != null ? sectorToStocksMap : new HashMap<>(),
@@ -365,4 +385,7 @@ public class AppContext {
         logger.info("AppContext shutdown process completed.");
     }
     // Add other getters as necessary
+    public MarketSentimentAnalyzer getMarketSentimentAnalyzer() {
+        return marketSentimentAnalyzer;
+    }
 }

--- a/kiteconnect/src/com/ibkr/models/OpeningMarketTrend.java
+++ b/kiteconnect/src/com/ibkr/models/OpeningMarketTrend.java
@@ -1,0 +1,9 @@
+package com.ibkr.models;
+
+public enum OpeningMarketTrend {
+    TREND_UP,               // Market has shown a clear upward trend after observation
+    TREND_DOWN,             // Market has shown a clear downward trend after observation
+    TREND_NEUTRAL,          // Market is mixed or flat after observation
+    OBSERVATION_PERIOD,     // Currently within the initial observation window, trend not yet determined
+    OUTSIDE_ANALYSIS_WINDOW // Not within the market opening analysis window (e.g., market closed, or past the initial period)
+}


### PR DESCRIPTION
This commit introduces a new strategy for the market opening phase (first 30 minutes). It determines an overall market trend based on an initial observation period and then generates trading signals for individual stocks that align with this trend.

Key Changes:

1.  **`OpeningMarketTrend` Enum:**
    - Added `com.ibkr.models.OpeningMarketTrend` enum (`TREND_UP`, `TREND_DOWN`, `TREND_NEUTRAL`, `OBSERVATION_PERIOD`, `OUTSIDE_ANALYSIS_WINDOW`).

2.  **`MarketSentimentAnalyzer.java` Enhancements:**
    - Now calculates an `OpeningMarketTrend` after a configurable observation period (e.g., 15 mins).
    - The trend is based on ~70% of monitored stocks moving in a common direction from their open.
    - Stores stock-specific opening prices and last prices during observation.
    - New methods: `updateOpeningTickAnalysis()`, `calculateDeterminedOpeningTrend()`, `getDeterminedOpeningTrend()`, `getStockOpeningPrices()`.

3.  **`AppContext.java` Configuration:**
    - Loads `market.opening.observation.minutes` from `app.properties`.
    - Instantiates `MarketSentimentAnalyzer` with new configuration (observation duration, market open time).
    - Provides a getter for `MarketSentimentAnalyzer`.

4.  **`TradingEngine.java` Refactoring:**
    - `generateOpeningSignals` signature changed to accept `OpeningMarketTrend`, map of stock opening prices, monitored symbols, and a map of current tick data for these symbols.
    - Generates BUY signals for stocks that are individually moving up strongly when the overall `OpeningMarketTrend` is `TREND_UP`. (SELL for `TREND_DOWN` can be a future addition).
    - Removed old `generateBullishSignals`/`generateBearishSignals`.

5.  **`TickProcessor.java` Orchestration:**
    - During the opening window, it calls `MarketSentimentAnalyzer.updateOpeningTickAnalysis()`.
    - Retrieves the `OpeningMarketTrend`.
    - If a clear trend (`TREND_UP`/`TREND_DOWN`) is established post-observation:
        - Gathers current tick data for all monitored symbols from `TickAggregator`.
        - Calls the new `TradingEngine.generateOpeningSignals()`. - Processes returned signals, ensuring they match the current tick's symbol and that no position already exists for that symbol from a prior opening signal.
    - Skips broad opening signal generation during the `OBSERVATION_PERIOD`.