### PR TITLE
Fix: Add missing previousLow to PreviousDayData and update usage

### DIFF
--- a/kiteconnect/src/com/ibkr/core/IBClient.java
+++ b/kiteconnect/src/com/ibkr/core/IBClient.java
@@ -396,6 +396,7 @@ public class IBClient implements EWrapper {
         PreviousDayData data = historicalDataRequests.get(reqId);
         if (data != null) {
             data.setPreviousHigh(bar.high());
+            data.setPreviousLow(bar.low()); // **** ADDED THIS LINE ****
             data.setPreviousClose(bar.close());
             // Assuming only one bar is expected for "1 D" duration
             successfullyFetchedPrevDayData.put(data.getSymbol(), data);
@@ -459,7 +460,7 @@ public class IBClient implements EWrapper {
             Contract contract = createStockContract(symbol, "SMART"); // Assuming SMART for all US stocks
             int reqId = appContext.getNextRequestId(); // Changed
 
-            PreviousDayData placeholder = new PreviousDayData(symbol, 0, 0);
+            PreviousDayData placeholder = new PreviousDayData(symbol, 0, 0, 0); // Add 0 for previousLow
             historicalDataRequests.put(reqId, placeholder);
 
             logger.debug("Requesting historical data for {}: ReqId={}, Contract={}, EndDT={}, Duration={}, BarSize={}, WhatToShow={}, UseRTH={}, Format={}",

--- a/kiteconnect/src/com/ibkr/models/PreviousDayData.java
+++ b/kiteconnect/src/com/ibkr/models/PreviousDayData.java
@@ -3,11 +3,13 @@ package com.ibkr.models;
 public class PreviousDayData {
     private final String symbol;
     private double previousHigh;
+    private double previousLow; // Added field
     private double previousClose;
 
-    public PreviousDayData(String symbol, double previousHigh, double previousClose) {
+    public PreviousDayData(String symbol, double previousHigh, double previousLow, double previousClose) {
         this.symbol = symbol;
         this.previousHigh = previousHigh;
+        this.previousLow = previousLow; // Added assignment
         this.previousClose = previousClose;
     }
 
@@ -23,6 +25,14 @@ public class PreviousDayData {
         this.previousHigh = previousHigh;
     }
 
+    public double getPreviousLow() { // Added getter
+        return previousLow;
+    }
+
+    public void setPreviousLow(double previousLow) { // Added setter
+        this.previousLow = previousLow;
+    }
+
     public double getPreviousClose() {
         return previousClose;
     }
@@ -36,6 +46,7 @@ public class PreviousDayData {
         return "PreviousDayData{" +
                 "symbol='" + symbol + '\'' +
                 ", previousHigh=" + previousHigh +
+                ", previousLow=" + previousLow + // Added to toString
                 ", previousClose=" + previousClose +
                 '}';
     }


### PR DESCRIPTION
This commit addresses a compiler error caused by a missing `getPreviousLow()` method and field in the `PreviousDayData` model.

Key changes:
- `PreviousDayData.java`:
    - Added `previousLow` field (double).
    - Updated constructor to include `previousLow`.
    - Added `getPreviousLow()` getter and `setPreviousLow()` setter.
    - Updated `toString()` to include `previousLow`.
- `IBClient.java`:
    - In `historicalData(reqId, bar)`: Now calls `data.setPreviousLow(bar.low())` to populate the low price from the historical bar.
    - In `fetchPreviousDayDataForAllStocks()`: Updated the placeholder `PreviousDayData` instantiation to match the new constructor signature.

These changes ensure that the previous day's low is correctly captured, stored, and made available, resolving the issue for components like `SupportResistanceAnalyzer`.