### PR TITLE
Implement Trade Execution Alerts to File

### DIFF
--- a/kiteconnect/src/com/ibkr/core/IBClient.java
+++ b/kiteconnect/src/com/ibkr/core/IBClient.java
@@ -4,6 +4,7 @@ import com.ib.client.*;
 import com.ib.client.OrderState; // Added for openOrder
 import com.ib.client.Execution;
 import com.ibkr.AppContext; // Added
+import com.ibkr.alert.TradeAlertLogger; // Added Import
 import com.ibkr.IBOrderExecutor;
 import com.ibkr.data.InstrumentRegistry;
 import com.ibkr.data.MarketDataHandler;
@@ -333,6 +334,9 @@ public class IBClient implements EWrapper {
         } else {
             logger.warn("orderExecutor is null. Cannot handle execution details for ReqId: {}", reqId);
         }
+
+        // Log the trade execution to TradeAlerts.txt
+        TradeAlertLogger.logTradeExecution(execution, contract);
     }
 
     @Override


### PR DESCRIPTION
This commit introduces a feature to log details of confirmed trade executions to a `TradeAlerts.txt` file in your project's root directory.

Key Changes:

1.  **New `TradeAlertLogger.java` class (in `com.ibkr.alert` package):**
    -   Responsible for formatting and writing trade execution details.
    -   The `logTradeExecution(Execution execution, Contract contract)` method is static and synchronized.
    -   Formats and appends a line to `TradeAlerts.txt` including:
        -   System Timestamp (when alert is logged)
        -   Symbol
        -   Action (BUY/SELL, parsed from IB's "BOT"/"SLD")
        -   Quantity
        -   Execution Price
        -   Order ID
        -   Execution ID
        -   IB Execution Time string
    -   Includes error handling for file I/O operations.

2.  **Modified `IBClient.java`:**
    -   In the `execDetails(int reqId, Contract contract, Execution execution)` EWrapper method, a call to `TradeAlertLogger.logTradeExecution(execution, contract)` has been added. This ensures that alerts are generated for each confirmed trade execution received from TWS.