### PR TITLE
Configure Logback for Console and File Logging

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,10 +1,25 @@
 <configuration>
+
+  <!-- Console Appender -->
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
+
+  <!-- File Appender -->
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <file>logs/TradingApp.log</file> <!-- Log file will be in 'logs' subdirectory -->
+    <append>true</append> <!-- Append to existing file, don't overwrite -->
+    <encoder>
+      <!-- Pattern includes date for file logs -->
+      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
   <root level="INFO">
-    <appender-ref ref="STDOUT" />
+    <appender-ref ref="STDOUT" /> <!-- Log to Console -->
+    <appender-ref ref="FILE" />   <!-- Log to File -->
   </root>
+
 </configuration>


### PR DESCRIPTION
I updated `src/main/resources/logback.xml` to enable logging to both the standard console output and a persistent file.

-   Console logging (STDOUT) remains as you previously configured.
-   I added a FileAppender (FILE) that writes logs to `logs/TradingApp.log`.
    -   The file appender is configured to append to the log file on subsequent application runs.
    -   It uses a log pattern that includes the full date and time.
-   The root logger is set to INFO level and now directs output to both STDOUT and FILE appenders.

This change allows for both real-time log viewing on the console and persistent log storage in a file for your later review and debugging.