### PR TITLE
Enhance BreakoutSignalGenerator with Support/Resistance Levels

### DIFF
--- a/kiteconnect/src/com/ibkr/AppContext.java
+++ b/kiteconnect/src/com/ibkr/AppContext.java
@@ -162,7 +162,11 @@ public class AppContext {
             this.marketSentimentAnalyzer, this.sectorStrengthAnalyzer, this.instrumentRegistry
         );
         this.breakoutSignalGenerator = new BreakoutSignalGenerator(
-            this.volatilityAnalyzer, this.vwapAnalyzer, this.volumeAnalyzer, this.sectorStrengthAnalyzer
+            this.volatilityAnalyzer,
+            this.vwapAnalyzer,
+            this.volumeAnalyzer,
+            this.sectorStrengthAnalyzer,
+            this.supportResistanceAnalyzer // Added supportResistanceAnalyzer
         );
         this.tickAggregator = new TickAggregator(this.instrumentRegistry);
 


### PR DESCRIPTION
This commit refactors `BreakoutSignalGenerator.java` to use Support/Resistance (S/R) levels for identifying breakout and breakdown opportunities, replacing the previous volatility-based movement calculation for entries.

Key Changes:

1.  **`BreakoutSignalGenerator.java`:**
    -   Added `SupportResistanceAnalyzer` as a constructor dependency.
    -   Reworked `isUpwardBreakout(Tick tick)`:
        -   A breakout is now signaled if the price crosses above a known resistance level.
        -   This is confirmed by:
            -   Price being above VWAP (`VWAPAnalyzer`).
            -   A significant volume spike (`VolumeAnalyzer`).
        -   Includes logic to identify a "just broken" level and to ensure the price is not already too far from the breakout point.
    -   Reworked `isDownwardBreakdown(Tick tick)`:
        -   Symmetrically, a breakdown is signaled if the price crosses below a known support level.
        -   Confirmed by price being below VWAP and a volume spike.
        -   Includes similar "just broken" and proximity logic.
    -   The older entry logic based purely on percentage movement scaled by volatility has been removed from these methods.

2.  **`AppContext.java`:**
    -   Updated the instantiation of `BreakoutSignalGenerator` to correctly pass the `SupportResistanceAnalyzer` instance.

This enhancement aims to improve the quality and reliability of breakout signals by incorporating key S/R levels into the decision-making process, alongside volume and VWAP analysis.