### PR TITLE
Refactor VolumeAnalyzer and Adjust BreakoutSignalGenerator Thresholds

### DIFF
--- a/kiteconnect/src/com/ibkr/indicators/VolumeAnalyzer.java
+++ b/kiteconnect/src/com/ibkr/indicators/VolumeAnalyzer.java
@@ -3,28 +3,58 @@ package com.ibkr.indicators;
 import com.zerodhatech.models.Tick;
 import java.util.ArrayDeque;
 import java.util.Queue;
+// import org.slf4j.Logger; // Example if logging is added
+// import org.slf4j.LoggerFactory; // Example if logging is added
 
 public class VolumeAnalyzer {
-    private final Queue<Long> volumeWindow = new ArrayDeque<>(20);
+    // private static final Logger logger = LoggerFactory.getLogger(VolumeAnalyzer.class); // Example
+    private final Queue<Double> volumeWindow = new ArrayDeque<>(20); // Changed to Double
     private double rollingSum = 0;
 
     public void update(Tick tick) {
-        if (volumeWindow.size() >= 20) {
-            rollingSum -= volumeWindow.poll();
+        if (tick == null) return;
+
+        double lastTradeVol = tick.getLastTradedQuantity();
+        if (lastTradeVol <= 0) {
+            // logger.trace("VolumeAnalyzer: Ignoring tick with zero or negative lastTradedQuantity for {}", tick.getSymbol());
+            return;
         }
-        volumeWindow.add(tick.getVolumeTradedToday());
-        rollingSum += tick.getVolumeTradedToday();
+
+        if (volumeWindow.size() >= 20) {
+            Double oldestVolume = volumeWindow.poll();
+            if (oldestVolume != null) {
+                rollingSum -= oldestVolume;
+            }
+        }
+        volumeWindow.add(lastTradeVol);
+        rollingSum += lastTradeVol;
     }
 
     public boolean isBreakoutWithSpike(Tick tick) {
+        if (tick == null || volumeWindow.isEmpty()) {
+            return false;
+        }
         double avgVolume = rollingSum / volumeWindow.size();
-        return tick.getVolumeTradedToday() > avgVolume * 2.5 &&
-                tick.getLastTradedPrice() > tick.getOpenPrice() * 1.01;
+        if (avgVolume <= 0) return false;
+
+        boolean volumeSpike = tick.getLastTradedQuantity() > avgVolume * 2.5;
+
+        // logger.trace("isBreakoutWithSpike for {}: LastVol={}, AvgVol={:.2f}, Spike={}",
+        //    tick.getSymbol(), tick.getLastTradedQuantity(), avgVolume, volumeSpike);
+        return volumeSpike;
     }
 
     public boolean isBreakdownWithSpike(Tick tick) {
+        if (tick == null || volumeWindow.isEmpty()) {
+            return false;
+        }
         double avgVolume = rollingSum / volumeWindow.size();
-        return tick.getVolumeTradedToday() > avgVolume * 2.5 &&
-                tick.getLastTradedPrice() < tick.getOpenPrice() * 0.99;
+        if (avgVolume <= 0) return false;
+
+        boolean volumeSpike = tick.getLastTradedQuantity() > avgVolume * 2.5;
+
+        // logger.trace("isBreakdownWithSpike for {}: LastVol={}, AvgVol={:.2f}, Spike={}",
+        //    tick.getSymbol(), tick.getLastTradedQuantity(), avgVolume, volumeSpike);
+        return volumeSpike;
     }
 }

--- a/kiteconnect/src/com/ibkr/signal/BreakoutSignalGenerator.java
+++ b/kiteconnect/src/com/ibkr/signal/BreakoutSignalGenerator.java
@@ -99,7 +99,7 @@ public class BreakoutSignalGenerator {
             if (level.getType() == com.ibkr.models.LevelType.RESISTANCE) {
                 boolean conditionOpenBelow = tick.getOpenPrice() <= level.getLevelPrice();
                 boolean conditionLtpAbove = tick.getLastTradedPrice() > level.getLevelPrice();
-                boolean conditionNotTooFar = tick.getLastTradedPrice() <= (level.getLevelPrice() * 1.005);
+                boolean conditionNotTooFar = tick.getLastTradedPrice() <= (level.getLevelPrice() * 1.010); // Changed 0.5% to 1.0%
 
                 if (conditionLtpAbove && conditionOpenBelow && conditionNotTooFar) {
                     resistanceBroken = true;
@@ -108,7 +108,7 @@ public class BreakoutSignalGenerator {
                         tick.getSymbol(), brokenResistanceLevel, tick.getOpenPrice(), tick.getLastTradedPrice());
                     break;
                 } else {
-                    logger.trace("isUpwardBreakout for {}: Resistance level {:.2f} not met for breakout. Open: {:.2f}, LTP: {:.2f}, LTP > R: {}, Open <= R: {}, LTP <= R*1.005: {}",
+                    logger.trace("isUpwardBreakout for {}: Resistance level {:.2f} not met for breakout. Open: {:.2f}, LTP: {:.2f}, LTP > R: {}, Open <= R: {}, LTP <= R*1.010: {}",
                         tick.getSymbol(), level.getLevelPrice(), tick.getOpenPrice(), tick.getLastTradedPrice(), conditionLtpAbove, conditionOpenBelow, conditionNotTooFar);
                 }
             }
@@ -158,7 +158,7 @@ public class BreakoutSignalGenerator {
             if (level.getType() == com.ibkr.models.LevelType.SUPPORT) {
                 boolean conditionOpenAbove = tick.getOpenPrice() >= level.getLevelPrice();
                 boolean conditionLtpBelow = tick.getLastTradedPrice() < level.getLevelPrice();
-                boolean conditionNotTooFar = tick.getLastTradedPrice() >= (level.getLevelPrice() * 0.995);
+                boolean conditionNotTooFar = tick.getLastTradedPrice() >= (level.getLevelPrice() * 0.990); // Changed 0.5% to 1.0%
 
                 if (conditionLtpBelow && conditionOpenAbove && conditionNotTooFar) {
                     supportBroken = true;
@@ -167,7 +167,7 @@ public class BreakoutSignalGenerator {
                         tick.getSymbol(), brokenSupportLevel, tick.getOpenPrice(), tick.getLastTradedPrice());
                     break;
                 } else {
-                     logger.trace("isDownwardBreakdown for {}: Support level {:.2f} not met for breakdown. Open: {:.2f}, LTP: {:.2f}, LTP < S: {}, Open >= S: {}, LTP >= S*0.995: {}",
+                     logger.trace("isDownwardBreakdown for {}: Support level {:.2f} not met for breakdown. Open: {:.2f}, LTP: {:.2f}, LTP < S: {}, Open >= S: {}, LTP >= S*0.990: {}",
                         tick.getSymbol(), level.getLevelPrice(), tick.getOpenPrice(), tick.getLastTradedPrice(), conditionLtpBelow, conditionOpenAbove, conditionNotTooFar);
                 }
             }


### PR DESCRIPTION
This commit addresses potential reasons for a lack of trade signals by:

1.  **Refactoring `VolumeAnalyzer.java`:**
    -   I changed the internal rolling volume calculations to use `tick.getLastTradedQuantity()` instead of `tick.getVolumeTradedToday()`. This provides a more accurate measure of recent per-trade/tick volume for spike detection.
    -   I removed the price movement conditions (e.g., price >1% from open) from `isBreakoutWithSpike` and `isBreakdownWithSpike` methods, making the analyzer focus purely on volume anomalies. Price confirmation is handled by the signal generators.

2.  **Adjusting `BreakoutSignalGenerator.java` Thresholds:**
    -   I widened the confirmation window for S/R level breaks in `isUpwardBreakout` and `isDownwardBreakdown` methods from 0.5% to 1.0% past the level. This allows for slightly more price movement after a break while still considering it a valid initial signal.

These changes aim to make volume spike detection more accurate and the S/R breakout conditions slightly less restrictive, potentially leading to more reliable signal generation.