### PR TITLE
Add utility to get last completed 1-min bar volume

### DIFF
--- a/kiteconnect/src/com/ibkr/AppContext.java
+++ b/kiteconnect/src/com/ibkr/AppContext.java
@@ -414,6 +414,10 @@ public class AppContext {
         return volatilityAnalyzer;
     }
 
+    public TradingEngine getTradingEngine() { // Added getter for TradingEngine
+        return tradingEngine;
+    }
+
     // Methods for PDH data handling specific to historical requests
     public void registerHistoricalDataRequest(int reqId, String symbol) {
         if (symbol == null || symbol.trim().isEmpty()) {

--- a/kiteconnect/src/com/ibkr/core/TradingEngine.java
+++ b/kiteconnect/src/com/ibkr/core/TradingEngine.java
@@ -41,13 +41,13 @@ public class TradingEngine {
     private final OrbStrategy orbStrategy; // +OrbStrategy
 
     // Data structures for ORB Strategy support
-    /** Inner class to hold OHLC and Volume for a bar */
-    private static class BarData {
-        final OHLC ohlc;
-        final long volume;
-        final long timestamp; // Start timestamp of the bar
+    /** Inner public static class to hold OHLC and Volume for a bar, accessible by DataUtils */
+    public static class BarData {
+        public final OHLC ohlc;
+        public final long volume;
+        public final long timestamp; // Start timestamp of the bar
 
-        BarData(OHLC ohlc, long volume, long timestamp) {
+        public BarData(OHLC ohlc, long volume, long timestamp) {
             this.ohlc = ohlc;
             this.volume = volume;
             this.timestamp = timestamp;
@@ -437,4 +437,19 @@ public class TradingEngine {
     }
 
     // Removed generateBullishSignals and generateBearishSignals methods
+
+    /**
+     * Retrieves the most recently completed 1-minute bar data for a symbol.
+     * @param symbol The stock symbol.
+     * @return The last BarData object, or null if no history exists for the symbol.
+     */
+    public BarData getLastCompletedBarData(String symbol) {
+        List<BarData> history = oneMinuteBarsHistory.get(symbol);
+        if (history != null && !history.isEmpty()) {
+            // The last element in the list is the most recently added (completed) bar
+            return history.get(history.size() - 1);
+        }
+        logger.debug("No 1-minute bar history found for symbol {} when requesting last completed bar.", symbol);
+        return null;
+    }
 }

--- a/kiteconnect/src/com/ibkr/utils/DataUtils.java
+++ b/kiteconnect/src/com/ibkr/utils/DataUtils.java
@@ -47,4 +47,60 @@ public class DataUtils {
             return null;
         }
     }
+
+    /**
+     * Retrieves the volume of the last completed 1-minute bar for a given stock symbol.
+     *
+     * This method relies on the {@link TradingEngine} having its {@code oneMinuteBarsHistory}
+     * populated by processing 1-minute bar data.
+     *
+     * @param appContext The application context, used to access the TradingEngine.
+     * @param symbol The stock symbol (e.g., "AAPL") for which to find the volume.
+     * @return The volume of the last completed 1-minute bar as a Long, or {@code null}
+     *         if appContext, symbol is invalid, TradingEngine is not found, or no bar data exists.
+     */
+    public static Long getLastCompletedOneMinuteBarVolume(AppContext appContext, String symbol) {
+        if (appContext == null) {
+            logger.warn("AppContext is null. Cannot retrieve last 1-min bar volume.");
+            return null;
+        }
+        if (symbol == null || symbol.trim().isEmpty()) {
+            logger.warn("Symbol is null or empty. Cannot retrieve last 1-min bar volume.");
+            return null;
+        }
+
+        // AppContext needs a getter for TradingEngine. Assuming it exists or will be added.
+        // For now, this is a conceptual access path. If AppContext doesn't directly expose TradingEngine,
+        // this utility might need to be re-thought or TradingEngine passed differently.
+        // Let's assume AppContext is refactored to provide access if it doesn't already.
+        // Conceptual: com.ibkr.core.TradingEngine tradingEngine = appContext.getTradingEngine();
+
+        // TODO: AppContext needs a getTradingEngine() method.
+        // This is a placeholder. In a real scenario, AppContext would provide access to TradingEngine.
+        // If direct access is not possible, this utility method might not be viable in this exact form
+        // or would need TradingEngine passed as a parameter instead of AppContext.
+        // For now, we'll proceed assuming a getter will be added to AppContext.
+
+        Object tradingEngineObj = null; // Placeholder for appContext.getTradingEngine();
+        // This part will fail if AppContext doesn't have getTradingEngine()
+        // We need to add getTradingEngine() to AppContext first.
+        // For the purpose of this step, let's assume it's available.
+        // In a real flow, I'd add it to AppContext then come back here.
+
+        com.ibkr.core.TradingEngine tradingEngine = appContext.getTradingEngine(); // Assume this method exists
+
+        if (tradingEngine == null) {
+            logger.warn("TradingEngine not available from AppContext. Cannot retrieve last 1-min bar volume for {}.", symbol);
+            return null;
+        }
+
+        com.ibkr.core.TradingEngine.BarData lastBarData = tradingEngine.getLastCompletedBarData(symbol);
+
+        if (lastBarData != null) {
+            return lastBarData.volume;
+        } else {
+            logger.debug("No completed 1-minute bar data found in TradingEngine for symbol: {} to get volume.", symbol);
+            return null; // Or 0L if that's preferred for "no volume" vs "no data"
+        }
+    }
 }


### PR DESCRIPTION
- Added DataUtils.getLastCompletedOneMinuteBarVolume(appContext, symbol).
- Enhanced TradingEngine to expose last completed BarData (OHLCV).
- Added getTradingEngine() getter to AppContext.