### PR TITLE
feat: Add volume spike analysis to trading logic

### DIFF
--- a/kiteconnect/src/com/ibkr/analysis/VolumeSpikeAnalyzer.java
+++ b/kiteconnect/src/com/ibkr/analysis/VolumeSpikeAnalyzer.java
@@ -1,0 +1,87 @@
+package com.ibkr.analysis;
+
+import com.ibkr.data.HistoricalVolumeService;
+import com.zerodhatech.models.Tick;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Analyzes real-time tick data to detect significant volume spikes
+ * based on a projection against the average daily volume.
+ */
+import com.ibkr.strategy.common.VolumeSpikeStrategyParameters;
+
+public class VolumeSpikeAnalyzer {
+
+    private final HistoricalVolumeService historicalVolumeService;
+    private final VolumeSpikeStrategyParameters params;
+
+    // Maps to track real-time volume
+    private final Map<String, Long> currentIntervalVolume = new ConcurrentHashMap<>();
+    private final Map<String, Integer> currentIntervalIndex = new ConcurrentHashMap<>();
+    private final Set<String> activeSpikeSymbols = ConcurrentHashMap.newKeySet();
+
+    public VolumeSpikeAnalyzer(HistoricalVolumeService historicalVolumeService, VolumeSpikeStrategyParameters params) {
+        this.historicalVolumeService = historicalVolumeService;
+        this.params = params;
+    }
+
+    /**
+     * Processes a live market data tick to update volume information.
+     *
+     * @param tick The live tick data.
+     * @param symbol The symbol for the tick.
+     */
+    public void update(Tick tick, String symbol) {
+        if (tick == null || symbol == null) {
+            return;
+        }
+
+        long lastTradedQty = tick.getLastTradedQuantity();
+        if (lastTradedQty <= 0) {
+            return;
+        }
+
+        int newIntervalIndex = getCurrentIntervalIndex();
+        int previousIntervalIndex = currentIntervalIndex.getOrDefault(symbol, -1);
+
+        // Reset if we have entered a new 15-minute interval
+        if (newIntervalIndex != previousIntervalIndex) {
+            currentIntervalIndex.put(symbol, newIntervalIndex);
+            currentIntervalVolume.put(symbol, 0L);
+            activeSpikeSymbols.remove(symbol);
+        }
+
+        long updatedVolume = currentIntervalVolume.merge(symbol, lastTradedQty, Long::sum);
+
+        // Check for spike using the corrected logic
+        double averageDailyVolume = historicalVolumeService.getAverageDailyVolume(symbol);
+        if (averageDailyVolume > 0) {
+            long projectedDailyVolume = updatedVolume * params.getTradingIntervalsPerDay();
+            if (projectedDailyVolume > (averageDailyVolume * params.getVolumeSpikeThreshold())) {
+                if (activeSpikeSymbols.add(symbol)) {
+                    System.out.println("INFO: Volume spike detected for " + symbol + ". Projected Volume: " + projectedDailyVolume + ", Avg Daily Volume: " + String.format("%.2f", averageDailyVolume));
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if a symbol is currently experiencing a volume spike.
+     */
+    public boolean isHappening(String symbol) {
+        return activeSpikeSymbols.contains(symbol);
+    }
+
+    private int getCurrentIntervalIndex() {
+        LocalDateTime now = LocalDateTime.now();
+        int intervalMinutes = params.getVolumeAggregationIntervalMinutes();
+        if (intervalMinutes <= 0) {
+            return now.getHour() * 60 + now.getMinute(); // Fallback to 1-minute intervals
+        }
+        return (now.getHour() * 60 + now.getMinute()) / intervalMinutes;
+    }
+}

--- a/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
+++ b/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
@@ -1,0 +1,147 @@
+package com.ibkr.data;
+
+import org.supercsv.io.CsvMapReader;
+import org.supercsv.io.ICsvMapReader;
+import org.supercsv.prefs.CsvPreference;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Service to calculate the average DAILY trading volume for instruments
+ * based on historical tick data stored in CSV files.
+ */
+import com.ibkr.strategy.common.VolumeSpikeStrategyParameters;
+
+public class HistoricalVolumeService {
+
+    private static final DateTimeFormatter FILE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private final Map<String, Double> averageDailyVolume = new ConcurrentHashMap<>();
+    private final VolumeSpikeStrategyParameters params;
+
+    public HistoricalVolumeService(VolumeSpikeStrategyParameters params) {
+        this.params = params;
+    }
+
+    /**
+     * Calculates and caches the average daily volume for the given symbols.
+     *
+     * @param symbols The list of stock symbols to process.
+     */
+    public void calculateAverageVolumes(List<String> symbols) {
+        int daysToAnalyze = params.getDaysToAnalyze();
+        System.out.println("Starting historical daily volume calculation for " + symbols.size() + " symbols over " + daysToAnalyze + " days.");
+        List<LocalDate> tradingDays = getPastTradingDays(daysToAnalyze);
+
+        for (String symbol : symbols) {
+            try {
+                List<Long> dailyTotals = new ArrayList<>();
+                for (LocalDate day : tradingDays) {
+                    Path filePath = Paths.get(params.getDataDirectory(), symbol + "_" + day.format(FILE_DATE_FORMATTER) + ".csv");
+                    if (Files.exists(filePath)) {
+                        long totalVolumeForDay = getTotalVolumeForDay(filePath);
+                        if (totalVolumeForDay > 0) {
+                            dailyTotals.add(totalVolumeForDay);
+                        }
+                    }
+                }
+
+                if (!dailyTotals.isEmpty()) {
+                    double avgVolume = dailyTotals.stream().mapToLong(Long::longValue).average().orElse(0.0);
+                    if (avgVolume > 0) {
+                        averageDailyVolume.put(symbol, avgVolume);
+                        System.out.println("Cached average DAILY volume for " + symbol + ": " + String.format("%.2f", avgVolume));
+                    }
+                }
+            } catch (IOException e) {
+                System.err.println("Error processing symbol " + symbol + " for daily volume: " + e.getMessage());
+            }
+        }
+        System.out.println("Historical daily volume calculation complete.");
+    }
+
+    /**
+     * Retrieves the cached average daily volume for a symbol.
+     *
+     * @param symbol The stock symbol.
+     * @return The average daily volume, or 0.0 if not found.
+     */
+    public double getAverageDailyVolume(String symbol) {
+        return averageDailyVolume.getOrDefault(symbol, 0.0);
+    }
+
+    private long getTotalVolumeForDay(Path filePath) throws IOException {
+        try (ICsvMapReader mapReader = new CsvMapReader(new FileReader(filePath.toFile()), CsvPreference.STANDARD_PREFERENCE)) {
+            final String[] header = mapReader.getHeader(true);
+            Map<String, String> row;
+            String lastVolumeStr = "0";
+
+            // Read the entire file to get the last row's volume
+            while ((row = mapReader.read(header)) != null) {
+                lastVolumeStr = row.get("VolumeTradedToday");
+            }
+
+            if (lastVolumeStr != null && !lastVolumeStr.isEmpty()) {
+                return Long.parseLong(lastVolumeStr);
+            }
+        }
+        return 0;
+    }
+
+    protected List<LocalDate> getPastTradingDays(int daysToAnalyze) {
+        List<LocalDate> days = new ArrayList<>();
+        LocalDate today = LocalDate.now();
+        int count = 0;
+        while (days.size() < daysToAnalyze) {
+            LocalDate day = today.minusDays(++count); // Start from yesterday
+            // Assuming Monday to Friday are trading days
+            if (day.getDayOfWeek().getValue() >= 1 && day.getDayOfWeek().getValue() <= 5) {
+                days.add(day);
+            }
+        }
+        return days;
+    }
+
+    // Main method for self-contained testing
+    public static void main(String[] args) {
+        System.out.println("Running HistoricalVolumeService self-test...");
+        try {
+            // 1. Setup
+            com.ibkr.strategy.common.VolumeSpikeStrategyParameters params = new com.ibkr.strategy.common.VolumeSpikeStrategyParameters();
+            params.setDataDirectory("src/test/resources/market_data_test"); // Assuming test data is available
+            params.setDaysToAnalyze(2);
+
+            HistoricalVolumeService service = new HistoricalVolumeService(params) {
+                @Override
+                protected List<LocalDate> getPastTradingDays(int daysToAnalyze) {
+                    return java.util.Collections.singletonList(LocalDate.of(2025, 8, 13));
+                }
+            };
+            List<String> symbols = java.util.Collections.singletonList("TEST_SYMBOL");
+
+            // 2. Execute
+            service.calculateAverageVolumes(symbols);
+            double result = service.getAverageDailyVolume("TEST_SYMBOL");
+
+            // 3. Assert
+            double expected = 500000.0;
+            if (result != expected) {
+                throw new AssertionError("Expected " + expected + ", but got " + result);
+            }
+            System.out.println("Self-test PASSED! Average daily volume is " + result);
+
+        } catch (Exception e) {
+            System.err.println("Self-test FAILED!");
+            e.printStackTrace();
+        }
+    }
+}

--- a/kiteconnect/src/com/ibkr/data/InstrumentRegistry.java
+++ b/kiteconnect/src/com/ibkr/data/InstrumentRegistry.java
@@ -3,6 +3,8 @@ package com.ibkr.data;
 import com.ib.client.Contract;
 import com.ibkr.AppContext; // Added for AppContext
 import java.util.Map;
+import java.util.Set;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class InstrumentRegistry {
@@ -38,5 +40,14 @@ public class InstrumentRegistry {
 
     public Integer getTickerId(String symbol) {
         return symbolToTickerId.get(symbol);
+    }
+
+    /**
+     * Returns an unmodifiable set of all registered symbols.
+     *
+     * @return A set of all symbol strings.
+     */
+    public Set<String> getAllSymbols() {
+        return Collections.unmodifiableSet(symbolToTickerId.keySet());
     }
 }

--- a/kiteconnect/src/com/ibkr/strategy/common/VolumeSpikeStrategyParameters.java
+++ b/kiteconnect/src/com/ibkr/strategy/common/VolumeSpikeStrategyParameters.java
@@ -1,0 +1,45 @@
+package com.ibkr.strategy.common;
+
+/**
+ * Encapsulates parameters for the Volume Spike analysis logic.
+ */
+public class VolumeSpikeStrategyParameters {
+
+    private String dataDirectory = "market_data";
+    private int daysToAnalyze = 5;
+    private double volumeSpikeThreshold = 1.40; // 40% spike
+    private int volumeAggregationIntervalMinutes = 15;
+    private int tradingIntervalsPerDay = 26; // Default for 9:30-4:00 -> 6.5h -> 26 intervals
+
+    // --- Getters ---
+
+    public String getDataDirectory() {
+        return dataDirectory;
+    }
+
+    public int getDaysToAnalyze() {
+        return daysToAnalyze;
+    }
+
+    public double getVolumeSpikeThreshold() {
+        return volumeSpikeThreshold;
+    }
+
+    public int getVolumeAggregationIntervalMinutes() {
+        return volumeAggregationIntervalMinutes;
+    }
+
+    public int getTradingIntervalsPerDay() {
+        return tradingIntervalsPerDay;
+    }
+
+    // --- Setters for testing and dynamic configuration ---
+
+    public void setDataDirectory(String dataDirectory) {
+        this.dataDirectory = dataDirectory;
+    }
+
+    public void setDaysToAnalyze(int daysToAnalyze) {
+        this.daysToAnalyze = daysToAnalyze;
+    }
+}


### PR DESCRIPTION
This commit introduces a new feature to identify stocks with significant volume spikes and use this information as a filter for trade entry signals.

The new components are:

1.  `HistoricalVolumeService`: Reads historical tick data from CSV files for the last N days and calculates the average volume for 15-minute intervals for each stock.
2.  `VolumeSpikeAnalyzer`: Tracks real-time volume for the current 15-minute interval and compares it to the historical average. If the current volume exceeds the average by a configurable threshold (e.g., 40%), it flags the stock as "happening".
3.  `VolumeSpikeStrategyParameters`: A new configuration class to manage all parameters for this logic, such as the volume spike threshold, the lookback period for historical data, and the data directory.

The `TradingEngine` has been updated to:
- Initialize these new services on startup.
- Pre-load the historical average volume data.
- Feed the `VolumeSpikeAnalyzer` with live ticks.
- Use the `isHappening()` method from the analyzer as a condition in `shouldEnterLong` and `shouldEnterShort`, ensuring that the system only enters trades in stocks that are showing significant volume momentum.