### PR TITLE
feat: Fetch historical volume data from IBKR API

### DIFF
--- a/kiteconnect/src/com/ibkr/IBKRApiService.java
+++ b/kiteconnect/src/com/ibkr/IBKRApiService.java
@@ -1,0 +1,450 @@
+package com.ibkr;
+
+import com.ib.client.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class IBKRApiService implements EWrapper {
+
+    private final EClientSocket client;
+    private final EReaderSignal signal;
+    private int nextReqId = 1;
+
+    private final Map<Integer, CompletableFuture<Double>> historicalDataFutures = new ConcurrentHashMap<>();
+    private final Map<Integer, List<Bar>> historicalDataBars = new ConcurrentHashMap<>();
+
+    public IBKRApiService() {
+        this.signal = new EJavaSignal();
+        this.client = new EClientSocket(this, signal);
+    }
+
+    public void connect(String host, int port, int clientId) {
+        client.eConnect(host, port, clientId);
+        final EReader reader = new EReader(client, signal);
+        reader.start();
+
+        new Thread(() -> {
+            while (client.isConnected()) {
+                signal.waitForSignal();
+                try {
+                    reader.processMsgs();
+                } catch (Exception e) {
+                    System.out.println("Exception: " + e.getMessage());
+                }
+            }
+        }).start();
+    }
+
+    public void disconnect() {
+        client.eDisconnect();
+    }
+
+    public CompletableFuture<Double> getAverageDailyVolume(String symbol) {
+        CompletableFuture<Double> future = new CompletableFuture<>();
+        int reqId = nextReqId++;
+        historicalDataFutures.put(reqId, future);
+        historicalDataBars.put(reqId, new ArrayList<>());
+
+        Contract contract = new Contract();
+        contract.symbol(symbol);
+        contract.secType("STK");
+        contract.exchange("SMART");
+        contract.currency("USD");
+
+        client.reqHistoricalData(
+                reqId,
+                contract,
+                "",
+                "5 D",
+                "1 day",
+                "TRADES",
+                1,
+                1,
+                false,
+                null);
+
+        return future;
+    }
+
+    @Override
+    public void historicalData(int reqId, Bar bar) {
+        List<Bar> bars = historicalDataBars.get(reqId);
+        if (bars != null) {
+            bars.add(bar);
+        }
+    }
+
+    @Override
+    public void historicalDataEnd(int reqId, String startDateStr, String endDateStr) {
+        CompletableFuture<Double> future = historicalDataFutures.remove(reqId);
+        List<Bar> bars = historicalDataBars.remove(reqId);
+
+        if (future != null) {
+            if (bars != null && !bars.isEmpty()) {
+                double totalVolume = 0;
+                for (Bar bar : bars) {
+                    totalVolume += bar.volume();
+                }
+                future.complete(totalVolume / bars.size());
+            } else {
+                future.complete(0.0);
+            }
+        }
+    }
+
+    @Override
+    public void error(int id, int errorCode, String errorMsg) {
+        CompletableFuture<Double> future = historicalDataFutures.remove(id);
+        if (future != null) {
+            future.completeExceptionally(new RuntimeException("IBKR API Error. Id: " + id + ", Code: " + errorCode + ", Msg: " + errorMsg));
+        }
+    }
+
+    @Override
+    public void tickPrice(int tickerId, int field, double price, TickAttrib attrib) {
+    }
+
+    @Override
+    public void tickSize(int tickerId, int field, int size) {
+    }
+
+    @Override
+    public void tickOptionComputation(int tickerId, int field, double impliedVol, double delta, double optPrice,
+            double pvDividend, double gamma, double vega, double theta, double undPrice) {
+    }
+
+    @Override
+    public void tickGeneric(int tickerId, int tickType, double value) {
+    }
+
+    @Override
+    public void tickString(int tickerId, int tickType, String value) {
+    }
+
+    @Override
+    public void tickEFP(int tickerId, int tickType, double basisPoints, String formattedBasisPoints,
+            double impliedFuture, int holdDays, String futureLastTradeDate, double dividendImpact,
+            double dividendsToLastTradeDate) {
+    }
+
+    @Override
+    public void orderStatus(int orderId, String status, double filled, double remaining, double avgFillPrice,
+            int permId, int parentId, double lastFillPrice, int clientId, String whyHeld, double mktCapPrice) {
+    }
+
+    @Override
+    public void openOrder(int orderId, Contract contract, Order order, OrderState orderState) {
+    }
+
+    @Override
+    public void openOrderEnd() {
+    }
+
+    @Override
+    public void updateAccountValue(String key, String value, String currency, String accountName) {
+    }
+
+    @Override
+    public void updatePortfolio(Contract contract, double position, double marketPrice, double marketValue,
+            double averageCost, double unrealizedPNL, double realizedPNL, String accountName) {
+    }
+
+    @Override
+    public void updateAccountTime(String timeStamp) {
+    }
+
+    @Override
+    public void accountDownloadEnd(String accountName) {
+    }
+
+    @Override
+    public void nextValidId(int orderId) {
+    }
+
+    @Override
+    public void contractDetails(int reqId, ContractDetails contractDetails) {
+    }
+
+    @Override
+    public void bondContractDetails(int reqId, ContractDetails contractDetails) {
+    }
+
+    @Override
+    public void contractDetailsEnd(int reqId) {
+    }
+
+    @Override
+    public void execDetails(int reqId, Contract contract, Execution execution) {
+    }
+
+    @Override
+    public void execDetailsEnd(int reqId) {
+    }
+
+    @Override
+    public void updateMktDepth(int tickerId, int position, int operation, int side, double price, int size) {
+    }
+
+    @Override
+    public void updateMktDepthL2(int tickerId, int position, String marketMaker, int operation, int side,
+            double price, int size, boolean isSmartDepth) {
+    }
+
+    @Override
+    public void updateNewsBulletin(int msgId, int msgType, String message, String origExchange) {
+    }
+
+    @Override
+    public void managedAccounts(String accountsList) {
+    }
+
+    @Override
+    public void receiveFA(int faDataType, String xml) {
+    }
+
+    @Override
+    public void historicalDataUpdate(int reqId, Bar bar) {
+    }
+
+    @Override
+    public void commissionReport(CommissionReport commissionReport) {
+    }
+
+    @Override
+    public void position(String account, Contract contract, double pos, double avgCost) {
+    }
+
+    @Override
+    public void positionEnd() {
+    }
+
+    @Override
+    public void accountSummary(int reqId, String account, String tag, String value, String currency) {
+    }
+
+    @Override
+    public void accountSummaryEnd(int reqId) {
+    }
+
+    @Override
+    public void verifyMessageAPI(String apiData) {
+    }
+
+    @Override
+    public void verifyCompleted(boolean isSuccessful, String errorText) {
+    }
+
+    @Override
+    public void verifyAndAuthMessageAPI(String apiData, String xyzChallenge) {
+    }
+
+    @Override
+    public void verifyAndAuthCompleted(boolean isSuccessful, String errorText) {
+    }
+
+    @Override
+    public void displayGroupList(int reqId, String groups) {
+    }
+
+    @Override
+    public void displayGroupUpdated(int reqId, String contractInfo) {
+    }
+
+    @Override
+    public void error(Exception e) {
+    }
+
+    @Override
+    public void error(String str) {
+    }
+
+    @Override
+    public void connectionClosed() {
+    }
+
+    @Override
+    public void connectAck() {
+    }
+
+    @Override
+    public void positionMulti(int reqId, String account, String modelCode, Contract contract, double pos,
+            double avgCost) {
+    }
+
+    @Override
+    public void positionMultiEnd(int reqId) {
+    }
+
+    @Override
+    public void accountUpdateMulti(int reqId, String account, String modelCode, String key, String value,
+            String currency) {
+    }
+
+    @Override
+    public void accountUpdateMultiEnd(int reqId) {
+    }
+
+    @Override
+    public void securityDefinitionOptionalParameter(int reqId, String exchange, int underlyingConId,
+            String tradingClass, String multiplier, Set<String> expirations, Set<Double> strikes) {
+    }
+
+    @Override
+    public void securityDefinitionOptionalParameterEnd(int reqId) {
+    }
+
+    @Override
+    public void softDollarTiers(int reqId, SoftDollarTier[] tiers) {
+    }
+
+    @Override
+    public void familyCodes(FamilyCode[] familyCodes) {
+    }
+
+    @Override
+    public void symbolSamples(int reqId, ContractDescription[] contractDescriptions) {
+    }
+
+    @Override
+    public void mktDepthExchanges(DepthMktDataDescription[] depthMktDataDescriptions) {
+    }
+
+    @Override
+    public void tickNews(int tickerId, long timeStamp, String providerCode, String articleId, String headline,
+            String extraData) {
+    }
+
+    @Override
+    public void smartComponents(int reqId, Map<Integer, Map.Entry<String, Character>> theMap) {
+    }
+
+    @Override
+    public void tickReqParams(int tickerId, double minTick, String bboExchange, int snapshotPermissions) {
+    }
+
+    @Override
+    public void newsProviders(NewsProvider[] newsProviders) {
+    }
+
+    @Override
+    public void newsArticle(int requestId, int articleType, String articleText) {
+    }
+
+    @Override
+    public void historicalNews(int requestId, String time, String providerCode, String articleId, String headline) {
+    }
+
+    @Override
+    public void historicalNewsEnd(int requestId, boolean hasMore) {
+    }
+
+    @Override
+    public void headTimestamp(int reqId, String headTimestamp) {
+    }
+
+    @Override
+    public void histogramData(int reqId, List<HistogramEntry> items) {
+    }
+
+    @Override
+    public void rerouteMktDataReq(int reqId, int conId, String exchange) {
+    }
+
+    @Override
+    public void rerouteMktDepthReq(int reqId, int conId, String exchange) {
+    }
+
+    @Override
+    public void marketRule(int marketRuleId, PriceIncrement[] priceIncrements) {
+    }
+
+    @Override
+    public void pnl(int reqId, double dailyPnL, double unrealizedPnL, double realizedPnL) {
+    }
+
+    @Override
+    public void pnlSingle(int reqId, int pos, double dailyPnL, double unrealizedPnL, double realizedPnL,
+            double value) {
+    }
+
+    @Override
+    public void historicalTicks(int reqId, List<HistoricalTick> ticks, boolean done) {
+    }
+
+    @Override
+    public void historicalTicksBidAsk(int reqId, List<HistoricalTickBidAsk> ticks, boolean done) {
+    }
+
+    @Override
+    public void historicalTicksLast(int reqId, List<HistoricalTickLast> ticks, boolean done) {
+    }
+
+    @Override
+    public void tickByTickAllLast(int reqId, int tickType, long time, double price, int size,
+            TickAttribLast tickAttribLast, String exchange, String specialConditions) {
+    }
+
+    @Override
+    public void tickByTickBidAsk(int reqId, long time, double bidPrice, double askPrice, int bidSize, int askSize,
+            TickAttribBidAsk tickAttribBidAsk) {
+    }
+
+    @Override
+    public void tickByTickMidPoint(int reqId, long time, double midPoint) {
+    }
+
+    @Override
+    public void orderBound(long orderId, int apiClientId, int apiOrderId) {
+    }
+
+    @Override
+    public void completedOrder(Contract contract, Order order, OrderState orderState) {
+    }
+
+    @Override
+    public void completedOrdersEnd() {
+    }
+
+    @Override
+    public void tickSnapshotEnd(int reqId) {
+    }
+
+    @Override
+    public void marketDataType(int reqId, int marketDataType) {
+    }
+
+    @Override
+    public void fundamentalData(int reqId, String data) {
+    }
+
+    @Override
+    public void realtimeBar(int reqId, long time, double open, double high, double low, double close, long volume,
+            double wap, int count) {
+    }
+
+    @Override
+    public void scannerParameters(String xml) {
+    }
+
+    @Override
+    public void scannerData(int reqId, int rank, ContractDetails contractDetails, String distance, String benchmark,
+            String projection, String legsStr) {
+    }
+
+    @Override
+    public void scannerDataEnd(int reqId) {
+    }
+
+    @Override
+    public void currentTime(long time) {
+    }
+
+    @Override
+    public void deltaNeutralValidation(int reqId, DeltaNeutralContract deltaNeutralContract) {
+    }
+}

--- a/kiteconnect/src/com/ibkr/core/TradingEngine.java
+++ b/kiteconnect/src/com/ibkr/core/TradingEngine.java
@@ -13,6 +13,7 @@ import com.ibkr.strategy.orb.OrbStrategy; // +OrbStrategy
 import com.ibkr.strategy.common.OrbStrategyParameters; // +OrbStrategy
 import com.ibkr.strategy.common.VolumeSpikeStrategyParameters;
 import com.ibkr.AppContext; // +OrbStrategy
+import com.ibkr.IBKRApiService;
 import com.ibkr.analysis.IntradayPriceActionAnalyzer; // +PriceAction
 import com.ibkr.models.PriceActionSignal; // +PriceAction
 import com.ibkr.alert.TradeAlertLogger; // +Alerts
@@ -91,9 +92,10 @@ public class TradingEngine {
         this.intradayPriceActionAnalyzer = new IntradayPriceActionAnalyzer(this.appContext); // +PriceAction
 
         // Initialize Volume Spike Analysis components
-        VolumeSpikeStrategyParameters volumeParams = new VolumeSpikeStrategyParameters();
-        this.historicalVolumeService = new HistoricalVolumeService(volumeParams);
-        this.volumeSpikeAnalyzer = new VolumeSpikeAnalyzer(this.historicalVolumeService, volumeParams);
+        IBKRApiService ibkrApiService = new IBKRApiService();
+        ibkrApiService.connect("127.0.0.1", 7497, 0); // Make sure the port is correct
+        this.historicalVolumeService = new HistoricalVolumeService(ibkrApiService);
+        this.volumeSpikeAnalyzer = new VolumeSpikeAnalyzer(this.historicalVolumeService);
 
         // Load historical volume data at startup
         Set<String> symbolsToMonitor = instrumentRegistry.getAllSymbols();

--- a/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
+++ b/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
@@ -1,143 +1,68 @@
 package com.ibkr.data;
 
-import org.supercsv.io.CsvMapReader;
-import org.supercsv.io.ICsvMapReader;
-import org.supercsv.prefs.CsvPreference;
+import com.ibkr.IBKRApiService;
+import com.ibkr.strategy.common.VolumeSpikeStrategyParameters;
 
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-
-/**
- * Service to calculate the average DAILY trading volume for instruments
- * based on historical tick data stored in CSV files.
- */
-import com.ibkr.strategy.common.VolumeSpikeStrategyParameters;
+import java.util.concurrent.ExecutionException;
 
 public class HistoricalVolumeService {
 
-    private static final DateTimeFormatter FILE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
     private final Map<String, Double> averageDailyVolume = new ConcurrentHashMap<>();
-    private final VolumeSpikeStrategyParameters params;
+    private final IBKRApiService ibkrApiService;
 
-    public HistoricalVolumeService(VolumeSpikeStrategyParameters params) {
-        this.params = params;
+    public HistoricalVolumeService(IBKRApiService ibkrApiService) {
+        this.ibkrApiService = ibkrApiService;
     }
 
-    /**
-     * Calculates and caches the average daily volume for the given symbols.
-     *
-     * @param symbols The list of stock symbols to process.
-     */
     public void calculateAverageVolumes(List<String> symbols) {
-        int daysToAnalyze = params.getDaysToAnalyze();
-        System.out.println("Starting historical daily volume calculation for " + symbols.size() + " symbols over " + daysToAnalyze + " days.");
-        List<LocalDate> tradingDays = getPastTradingDays(daysToAnalyze);
+        System.out.println("Starting historical daily volume calculation for " + symbols.size() + " symbols using IBKR API.");
 
         for (String symbol : symbols) {
             try {
-                List<Long> dailyTotals = new ArrayList<>();
-                for (LocalDate day : tradingDays) {
-                    Path filePath = Paths.get(params.getDataDirectory(), symbol + "_" + day.format(FILE_DATE_FORMATTER) + ".csv");
-                    if (Files.exists(filePath)) {
-                        long totalVolumeForDay = getTotalVolumeForDay(filePath);
-                        if (totalVolumeForDay > 0) {
-                            dailyTotals.add(totalVolumeForDay);
-                        }
-                    }
+                CompletableFuture<Double> future = ibkrApiService.getAverageDailyVolume(symbol);
+                Double avgVolume = future.get(); // Blocking call to wait for the result
+                if (avgVolume > 0) {
+                    averageDailyVolume.put(symbol, avgVolume);
+                    System.out.println("Cached average DAILY volume for " + symbol + ": " + String.format("%.2f", avgVolume));
                 }
-
-                if (!dailyTotals.isEmpty()) {
-                    double avgVolume = dailyTotals.stream().mapToLong(Long::longValue).average().orElse(0.0);
-                    if (avgVolume > 0) {
-                        averageDailyVolume.put(symbol, avgVolume);
-                        System.out.println("Cached average DAILY volume for " + symbol + ": " + String.format("%.2f", avgVolume));
-                    }
-                }
-            } catch (IOException e) {
+            } catch (InterruptedException | ExecutionException e) {
                 System.err.println("Error processing symbol " + symbol + " for daily volume: " + e.getMessage());
             }
         }
         System.out.println("Historical daily volume calculation complete.");
     }
 
-    /**
-     * Retrieves the cached average daily volume for a symbol.
-     *
-     * @param symbol The stock symbol.
-     * @return The average daily volume, or 0.0 if not found.
-     */
     public double getAverageDailyVolume(String symbol) {
         return averageDailyVolume.getOrDefault(symbol, 0.0);
     }
 
-    private long getTotalVolumeForDay(Path filePath) throws IOException {
-        try (ICsvMapReader mapReader = new CsvMapReader(new FileReader(filePath.toFile()), CsvPreference.STANDARD_PREFERENCE)) {
-            final String[] header = mapReader.getHeader(true);
-            Map<String, String> row;
-            String lastVolumeStr = "0";
-
-            // Read the entire file to get the last row's volume
-            while ((row = mapReader.read(header)) != null) {
-                lastVolumeStr = row.get("VolumeTradedToday");
-            }
-
-            if (lastVolumeStr != null && !lastVolumeStr.isEmpty()) {
-                return Long.parseLong(lastVolumeStr);
-            }
-        }
-        return 0;
-    }
-
-    protected List<LocalDate> getPastTradingDays(int daysToAnalyze) {
-        List<LocalDate> days = new ArrayList<>();
-        LocalDate today = LocalDate.now();
-        int count = 0;
-        while (days.size() < daysToAnalyze) {
-            LocalDate day = today.minusDays(++count); // Start from yesterday
-            // Assuming Monday to Friday are trading days
-            if (day.getDayOfWeek().getValue() >= 1 && day.getDayOfWeek().getValue() <= 5) {
-                days.add(day);
-            }
-        }
-        return days;
-    }
-
-    // Main method for self-contained testing
     public static void main(String[] args) {
         System.out.println("Running HistoricalVolumeService self-test...");
         try {
             // 1. Setup
-            com.ibkr.strategy.common.VolumeSpikeStrategyParameters params = new com.ibkr.strategy.common.VolumeSpikeStrategyParameters();
-            params.setDataDirectory("src/test/resources/market_data_test"); // Assuming test data is available
-            params.setDaysToAnalyze(2);
+            IBKRApiService ibkrApiService = new IBKRApiService();
+            ibkrApiService.connect("127.0.0.1", 7497, 0); // Connect to TWS or Gateway
 
-            HistoricalVolumeService service = new HistoricalVolumeService(params) {
-                @Override
-                protected List<LocalDate> getPastTradingDays(int daysToAnalyze) {
-                    return java.util.Collections.singletonList(LocalDate.of(2025, 8, 13));
-                }
-            };
-            List<String> symbols = java.util.Collections.singletonList("TEST_SYMBOL");
+            HistoricalVolumeService service = new HistoricalVolumeService(ibkrApiService);
+            List<String> symbols = java.util.Collections.singletonList("AAPL");
 
             // 2. Execute
             service.calculateAverageVolumes(symbols);
-            double result = service.getAverageDailyVolume("TEST_SYMBOL");
+            double result = service.getAverageDailyVolume("AAPL");
 
             // 3. Assert
-            double expected = 500000.0;
-            if (result != expected) {
-                throw new AssertionError("Expected " + expected + ", but got " + result);
+            // The expected value will depend on the actual data from IBKR.
+            // For this test, we just check if the result is greater than 0.
+            if (result <= 0) {
+                throw new AssertionError("Expected a positive average volume, but got " + result);
             }
-            System.out.println("Self-test PASSED! Average daily volume is " + result);
+            System.out.println("Self-test PASSED! Average daily volume for AAPL is " + result);
+
+            ibkrApiService.disconnect();
 
         } catch (Exception e) {
             System.err.println("Self-test FAILED!");


### PR DESCRIPTION
This change modifies the VolumeSpikeAnalyzer to fetch historical volume data from the IBKR API instead of reading it from a CSV file. A new IBKRApiService is introduced to handle the communication with the IBKR API. The HistoricalVolumeService is updated to use the new service. The changes are tested with a self-test in HistoricalVolumeService.