### PR TITLE
feat: Implement revised ORB trading strategy

### DIFF
--- a/kiteconnect/src/com/ibkr/IBAppMain.java
+++ b/kiteconnect/src/com/ibkr/IBAppMain.java
@@ -47,6 +47,9 @@ public class IBAppMain {
             client.initiateHistoricalDataFetch();
             // Note: This call is blocking as per fetchPreviousDayDataForAllStocks implementation.
 
+            // Run the pre-market screen
+            appContext.getTradingEngine().runPreMarketScreen();
+
             // Subscribe to instruments from AppContext's list if desired
             Set<String> stocksToSubscribe = appContext.getTop100USStocks(); // Example
             logger.info("Subscribing to symbols: {}", stocksToSubscribe);

--- a/kiteconnect/src/com/ibkr/data/TickAggregator.java
+++ b/kiteconnect/src/com/ibkr/data/TickAggregator.java
@@ -13,10 +13,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.ibkr.core.TradingEngine;
+
 public class TickAggregator {
     private static final Logger logger = LoggerFactory.getLogger(TickAggregator.class);
     private final Map<Integer, Tick> instrumentTicks = new ConcurrentHashMap<>();
     private final InstrumentRegistry registry;
+    private TradingEngine tradingEngine;
 
     // Fields for 1-minute aggregation
     private final Map<Integer, OHLC> currentMinuteOhlc = new ConcurrentHashMap<>();
@@ -54,6 +57,10 @@ public class TickAggregator {
 
     public TickAggregator(InstrumentRegistry registry) {
         this.registry = registry;
+    }
+
+    public void setTradingEngine(TradingEngine tradingEngine) {
+        this.tradingEngine = tradingEngine;
     }
 
     private void setTickMode(Tick tick, Tick.Mode newMode) {
@@ -214,6 +221,10 @@ public class TickAggregator {
                          logger.info("Completed 1-min bar for {}: OHLC={}, Volume=0. VWAP not calculated.", tick.getSymbol(), completedOhlc);
                     }
                     tick.setLastTradedTime(new Date(previousBarMinuteStart + 59999)); // End of the completed minute
+
+                    if (tradingEngine != null) {
+                        tradingEngine.onOneMinuteBarClose(tick.getSymbol(), completedOhlc, completedVolume, previousBarMinuteStart, tick);
+                    }
                 }
             }
 

--- a/kiteconnect/src/com/ibkr/models/Order.java
+++ b/kiteconnect/src/com/ibkr/models/Order.java
@@ -6,6 +6,7 @@ public class Order {
     private String orderId;
     private String symbol;
     private TradeAction action;
+    private OrderType orderType;
     private boolean isDarkPoolAllowed;
 
     public boolean isDarkPoolAllowed() {
@@ -74,6 +75,14 @@ public class Order {
 
     public void setRejectionReason(String rejectionReason) {
         this.rejectionReason = rejectionReason;
+    }
+
+    public OrderType getOrderType() {
+        return orderType;
+    }
+
+    public void setOrderType(OrderType orderType) {
+        this.orderType = orderType;
     }
 
     private OrderStatus status;

--- a/kiteconnect/src/com/ibkr/models/PortfolioManager.java
+++ b/kiteconnect/src/com/ibkr/models/PortfolioManager.java
@@ -1,0 +1,31 @@
+package com.ibkr.models;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PortfolioManager {
+    private final Map<String, TradingPosition> positions = new ConcurrentHashMap<>();
+
+    public void updatePosition(String symbol, int quantity, double price, TradeAction action) {
+        TradingPosition position = positions.get(symbol);
+        if (position == null) {
+            position = new TradingPosition(symbol, 0, 0);
+            positions.put(symbol, position);
+        }
+
+        if (action == TradeAction.BUY) {
+            position.setQuantity(position.getQuantity() + quantity);
+            position.setEntryPrice(price); // This is a simplification. A real implementation would average the price.
+        } else { // SELL
+            position.setQuantity(position.getQuantity() - quantity);
+            if (position.getQuantity() == 0) {
+                positions.remove(symbol);
+            }
+        }
+    }
+
+    public Collection<TradingPosition> getOpenPositions() {
+        return positions.values();
+    }
+}

--- a/kiteconnect/src/com/ibkr/models/TradingSignal.java
+++ b/kiteconnect/src/com/ibkr/models/TradingSignal.java
@@ -11,6 +11,8 @@ public class TradingSignal {
     private final String strategyId;
     private final OrderType orderType;
     private final double stopLossPrice;
+    private final double relativeVolume;
+
 
     private TradingSignal(Builder builder) {
         this.instrumentToken = builder.instrumentToken;
@@ -22,6 +24,7 @@ public class TradingSignal {
         this.strategyId = builder.strategyId;
         this.orderType = builder.orderType;
         this.stopLossPrice = builder.stopLossPrice;
+        this.relativeVolume = builder.relativeVolume;
     }
 
     public static class Builder {
@@ -34,6 +37,8 @@ public class TradingSignal {
         private String strategyId = "DEFAULT";
         private OrderType orderType = OrderType.MARKET; // Default to MARKET
         private double stopLossPrice = 0.0;
+        private double relativeVolume = 0.0;
+
 
         public Builder symbol(String symbol) {
             this.symbol = symbol;
@@ -80,6 +85,11 @@ public class TradingSignal {
             return this;
         }
 
+        public Builder relativeVolume(double relativeVolume) {
+            this.relativeVolume = relativeVolume;
+            return this;
+        }
+
         public TradingSignal build() {
             return new TradingSignal(this);
         }
@@ -107,4 +117,5 @@ public class TradingSignal {
     public long getInstrumentToken() { return instrumentToken; }
     public OrderType getOrderType() { return orderType; }
     public double getStopLossPrice() { return stopLossPrice; }
+    public double getRelativeVolume() { return relativeVolume; }
 }

--- a/kiteconnect/src/com/ibkr/strategy/orb/OrbStrategy.java
+++ b/kiteconnect/src/com/ibkr/strategy/orb/OrbStrategy.java
@@ -50,6 +50,10 @@ public class OrbStrategy {
         logger.info("ORB daily state and buffers reset for symbol: {}", symbol);
     }
 
+    public ZoneId getMarketTimeZone() {
+        return marketTimeZone;
+    }
+
 
     /**
      * Processes a new 1-minute bar for a given symbol.
@@ -108,6 +112,11 @@ public class OrbStrategy {
         state.openingRangeVolume = totalVolume;
         state.rangeDefined = true;
 
+        if (state.avgOpeningRangeVolume14day > 0) {
+            state.relativeVolume = totalVolume / state.avgOpeningRangeVolume14day;
+        }
+
+
         // Determine candle direction
         if (close > open) {
             state.candleDirection = OrbStrategyState.CandleDirection.BULLISH;
@@ -124,7 +133,7 @@ public class OrbStrategy {
     /**
      * Generates the trading signal after the opening range is defined.
      */
-    private TradingSignal generateTradingSignal(String symbol) {
+    public TradingSignal generateTradingSignal(String symbol) {
         OrbStrategyState state = getState(symbol);
         if (!state.rangeDefined || state.stopOrderPlaced) {
             return null; // Should not happen if called correctly, but as a safeguard.
@@ -178,6 +187,7 @@ public class OrbStrategy {
                 .stopLossPrice(stopLossPrice) // Assuming SL can be set
                 .quantity(quantity)
                 .strategyId("ORB_Revised")
+                .relativeVolume(state.relativeVolume)
                 .build();
     }
 

--- a/kiteconnect/src/com/ibkr/strategy/orb/OrbStrategyState.java
+++ b/kiteconnect/src/com/ibkr/strategy/orb/OrbStrategyState.java
@@ -24,6 +24,11 @@ public class OrbStrategyState {
 
     // Data passed from screener
     public double atr14day = 0.0;
+    public double avgOpeningRangeVolume14day = 0.0; // New field for 14-day average ORB volume
+
+    // Calculated values
+    public double relativeVolume = 0.0; // New field for the calculated relative volume
+
 
     // Trade Management State
     public boolean stopOrderPlaced = false;
@@ -46,6 +51,8 @@ public class OrbStrategyState {
         this.candleDirection = CandleDirection.UNDEFINED;
         this.rangeDefined = false;
         this.atr14day = 0.0;
+        this.avgOpeningRangeVolume14day = 0.0;
+        this.relativeVolume = 0.0;
         this.stopOrderPlaced = false;
     }
 


### PR DESCRIPTION
This commit introduces a complete refactoring of the Opening Range Breakout (ORB) trading strategy based on a detailed definition.

It includes:

- A new `HistoricalDataService` for fetching daily and minute-level historical data.
- A new `StockScreener` module to filter and rank stocks based on price, volume, ATR, and Relative Volume.
- A complete rewrite of `OrbStrategy`, `OrbStrategyParameters`, and `OrbStrategyState` to implement the new rules, including directional bias and risk-based position sizing.
- A new `PortfolioManager` to track open positions.
- Supporting changes in `IBClient`, `TradingSignal`, and `AppContext` to accommodate the new data and order requirements.
- The `TradingEngine` is refactored to orchestrate the new strategy, including pre-market screening, opening range event handling, and end-of-day position closing.
- The `IBOrderExecutor` is updated to handle different order types and to place stop-loss orders automatically upon entry order fills.