### PR TITLE
Fix: Resolve connection hang in HistoricalVolumeService

### DIFF
--- a/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
+++ b/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
@@ -21,10 +21,15 @@ public class HistoricalVolumeService {
     public void calculateAverageVolumes(List<String> symbols) {
         System.out.println("Starting historical daily volume calculation for " + symbols.size() + " symbols using IBKR API.");
 
+        Map<String, CompletableFuture<Double>> futures = new ConcurrentHashMap<>();
         for (String symbol : symbols) {
+            futures.put(symbol, ibkrApiService.getAverageDailyVolume(symbol));
+        }
+
+        for (Map.Entry<String, CompletableFuture<Double>> entry : futures.entrySet()) {
+            String symbol = entry.getKey();
             try {
-                CompletableFuture<Double> future = ibkrApiService.getAverageDailyVolume(symbol);
-                Double avgVolume = future.get(); // Blocking call to wait for the result
+                Double avgVolume = entry.getValue().get(); // Blocking call to wait for the result
                 if (avgVolume > 0) {
                     averageDailyVolume.put(symbol, avgVolume);
                     System.out.println("Cached average DAILY volume for " + symbol + ": " + String.format("%.2f", avgVolume));
@@ -33,6 +38,7 @@ public class HistoricalVolumeService {
                 System.err.println("Error processing symbol " + symbol + " for daily volume: " + e.getMessage());
             }
         }
+
         System.out.println("Historical daily volume calculation complete.");
     }
 
@@ -42,10 +48,13 @@ public class HistoricalVolumeService {
 
     public static void main(String[] args) {
         System.out.println("Running HistoricalVolumeService self-test...");
+        IBKRApiService ibkrApiService = new IBKRApiService();
         try {
             // 1. Setup
-            IBKRApiService ibkrApiService = new IBKRApiService();
             ibkrApiService.connect("127.0.0.1", 7497, 0); // Connect to TWS or Gateway
+            System.out.println("Waiting for IBKR API connection to be established...");
+            ibkrApiService.awaitConnection();
+            System.out.println("IBKR API connection established.");
 
             HistoricalVolumeService service = new HistoricalVolumeService(ibkrApiService);
             List<String> symbols = java.util.Collections.singletonList("AAPL");
@@ -62,11 +71,12 @@ public class HistoricalVolumeService {
             }
             System.out.println("Self-test PASSED! Average daily volume for AAPL is " + result);
 
-            ibkrApiService.disconnect();
-
         } catch (Exception e) {
             System.err.println("Self-test FAILED!");
             e.printStackTrace();
+        } finally {
+            System.out.println("Disconnecting from IBKR API.");
+            ibkrApiService.disconnect();
         }
     }
 }


### PR DESCRIPTION
The application would hang when fetching historical data because API requests were being sent before the connection to the IBKR Gateway was fully established.

This commit introduces a robust connection handling mechanism:
- A `CompletableFuture` is now used in `IBKRApiService` to track the connection status.
- The `nextValidId` callback, which is the correct signal for a ready connection, now completes this future.
- The `main` method in `HistoricalVolumeService` now waits for this future to complete before sending any data requests.
- The `disconnect` call is now in a `finally` block to ensure it is always executed.

Additionally, the `calculateAverageVolumes` method has been refactored to fetch data for all symbols concurrently, significantly improving performance for multi-symbol requests.