### PR TITLE
Refactor: Restore average volume calculation in ORB strategy

### DIFF
--- a/kiteconnect/src/com/ibkr/core/TradingEngine.java
+++ b/kiteconnect/src/com/ibkr/core/TradingEngine.java
@@ -284,8 +284,12 @@ public class TradingEngine {
 
         // Call OrbStrategy
         if (orbStrategy != null) {
+            // Calculate average volume over the last 10 bars for context.
+            double averageVolume = calculateAverageVolume(symbol, 10);
+            OrbStrategy.VolumeData volumeData = new OrbStrategy.VolumeData(volumeForBar, averageVolume);
+
             // Pass the OHLC part of the new bar to the strategy
-            TradingSignal orbSignal = orbStrategy.processBar(symbol, ohlcPortion, volumeForBar, barTimestamp);
+            TradingSignal orbSignal = orbStrategy.processBar(symbol, ohlcPortion, barTimestamp, volumeData);
             if (orbSignal != null && orbSignal.getAction() != TradeAction.HOLD) {
                 logger.info("TradingEngine: ORB Strategy generated signal for {}: {}", symbol, orbSignal);
                 // The signal is not processed here anymore. It will be processed by the screener.

--- a/kiteconnect/src/com/ibkr/strategy/orb/OrbStrategyState.java
+++ b/kiteconnect/src/com/ibkr/strategy/orb/OrbStrategyState.java
@@ -28,6 +28,7 @@ public class OrbStrategyState {
 
     // Calculated values
     public double relativeVolume = 0.0; // New field for the calculated relative volume
+    public double averageVolumeLastN = 0.0; // Average volume of N bars before the ORB range
 
 
     // Trade Management State
@@ -53,6 +54,7 @@ public class OrbStrategyState {
         this.atr14day = 0.0;
         this.avgOpeningRangeVolume14day = 0.0;
         this.relativeVolume = 0.0;
+        this.averageVolumeLastN = 0.0;
         this.stopOrderPlaced = false;
     }
 


### PR DESCRIPTION
This commit restores the logic for calculating and using the average volume in the Opening Range Breakout (ORB) strategy, addressing a regression where this calculation was removed.

The following changes were made:
- Re-introduced the `OrbStrategy.VolumeData` class to encapsulate volume information.
- Modified `TradingEngine` to calculate the N-bar average volume and pass it to the `OrbStrategy`.
- Updated `OrbStrategy` to use this average volume as a confirmation filter, only generating a signal if the opening range volume is significantly higher than the recent average.

This restores the behavior described in the `README-LOGIC.md` and ensures the strategy does not trade on low-volume breakouts.