### PR TITLE
Fix: Correct historical average volume calculation logic

### DIFF
--- a/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
+++ b/kiteconnect/src/com/ibkr/data/HistoricalVolumeService.java
@@ -1,7 +1,9 @@
 package com.ibkr.data;
 
 import com.ibkr.service.MarketDataService;
-import com.ibkr.strategy.common.VolumeSpikeStrategyParameters;
+import com.ibkr.utils.TradingCalculations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -11,6 +13,7 @@ import java.util.concurrent.ExecutionException;
 
 public class HistoricalVolumeService {
 
+    private static final Logger logger = LoggerFactory.getLogger(HistoricalVolumeService.class);
     private final Map<String, Double> averageDailyVolume = new ConcurrentHashMap<>();
     private final MarketDataService marketDataService;
 
@@ -19,27 +22,40 @@ public class HistoricalVolumeService {
     }
 
     public void calculateAverageVolumes(List<String> symbols) {
-        System.out.println("Starting historical daily volume calculation for " + symbols.size() + " symbols using IBKR API.");
+        logger.info("Starting historical daily volume calculation for {} symbols.", symbols.size());
 
+        // We need 14 days of data to calculate a 14-day average.
+        // Requesting 15 to be safe, to account for today if it's a trading day but before market close.
+        final int requiredBars = 15;
         Map<String, CompletableFuture<Double>> futures = new ConcurrentHashMap<>();
         for (String symbol : symbols) {
-            futures.put(symbol, marketDataService.getAverageDailyVolume(symbol));
+            CompletableFuture<Double> avgVolumeFuture = marketDataService.getDailyHistoricalData(symbol, requiredBars)
+                    .thenApply(bars -> {
+                        if (bars == null || bars.isEmpty()) {
+                            logger.warn("Received empty or null historical data for {}. Cannot calculate average volume.", symbol);
+                            return 0.0;
+                        }
+                        return TradingCalculations.calculateAverageVolume(bars);
+                    });
+            futures.put(symbol, avgVolumeFuture);
         }
+
+        CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[0])).join(); // Wait for all futures to complete
 
         for (Map.Entry<String, CompletableFuture<Double>> entry : futures.entrySet()) {
             String symbol = entry.getKey();
             try {
-                Double avgVolume = entry.getValue().get(); // Blocking call to wait for the result
+                Double avgVolume = entry.getValue().get(); // This should not block as we joined above
                 if (avgVolume > 0) {
                     averageDailyVolume.put(symbol, avgVolume);
-                    System.out.println("Cached average DAILY volume for " + symbol + ": " + String.format("%.2f", avgVolume));
+                    logger.info("Cached average DAILY volume for {}: {}", symbol, String.format("%.2f", avgVolume));
                 }
             } catch (InterruptedException | ExecutionException e) {
-                System.err.println("Error processing symbol " + symbol + " for daily volume: " + e.getMessage());
+                logger.error("Error processing symbol {} for daily volume.", symbol, e);
             }
         }
 
-        System.out.println("Historical daily volume calculation complete.");
+        logger.info("Historical daily volume calculation complete.");
     }
 
     public double getAverageDailyVolume(String symbol) {


### PR DESCRIPTION
This commit addresses two separate but related issues with the calculation and loading of historical average volume data.

1.  **Fix startup data loading:** The `TradingEngine` constructor was attempting to load historical data for a list of symbols fetched from the `InstrumentRegistry`. This failed because the registry is populated after the engine is initialized. The code has been changed to use the predefined list of symbols from `AppContext`, ensuring volume data is loaded correctly at startup.

2.  **Correct volume calculation method:** The `HistoricalVolumeService` was incorrectly calling `marketDataService.getAverageDailyVolume()`, which was a circular and incorrect dependency. The service has been refactored to fetch the raw daily historical bars via `marketDataService.getDailyHistoricalData()` and then use the `TradingCalculations.calculateAverageVolume()` utility to compute the average volume.

These changes ensure that the historical volume data is calculated correctly and loaded reliably when the application starts.