### PR TITLE
feat: Use IbkrMarketDataService for live data

### DIFF
--- a/kiteconnect/src/com/ibkr/AppContext.java
+++ b/kiteconnect/src/com/ibkr/AppContext.java
@@ -135,14 +135,19 @@ public class AppContext {
 
         if (!isBacktest) {
             // Level 2: Create services
-            this.marketDataService = new BacktestMarketDataService("stockdata/MW-NIFTY-500-01-Nov-2024.csv");
+            // Pass null for TickProcessor to break circular dependency, it will be set later.
+            IbkrMarketDataService ibkrMarketDataService = new IbkrMarketDataService(this, this.instrumentRegistry, this.tickAggregator, null, this.marketDataHandler);
+            this.marketDataService = ibkrMarketDataService;
+            this.clientSocket = ibkrMarketDataService.getClientSocket();
+            this.readerSignal = ibkrMarketDataService.getReaderSignal();
+
 
             this.tradingEngine = new TradingEngine(this, orderService, this.marketDataService, portfolioManager, this.sectorStrengthAnalyzer);
 
             // TickProcessor is now simplified, it just needs to know about the engine to pass it bars.
             this.tickProcessor = new TickProcessor(this.breakoutSignalGenerator, this.riskManager, this.tradingEngine, orderService, this);
             // Now set the tick processor in the market data service
-//            ((IbkrMarketDataService)this.marketDataService).setTickProcessor(this.tickProcessor);
+            ((IbkrMarketDataService)this.marketDataService).setTickProcessor(this.tickProcessor);
 
 
             this.tickAggregator.setTradingEngine(this.tradingEngine);
@@ -150,8 +155,6 @@ public class AppContext {
 
 
             // Level 3: Components that depend on IbkrMarketDataService
-            this.clientSocket = null;
-            this.readerSignal = null;
             this.ibOrderExecutor.setClientSocket(this.clientSocket);
 
             // Final Step: Initialize TradingEngine services that required the IbkrMarketDataService, breaking the circular dependency.


### PR DESCRIPTION
Switched from `BacktestMarketDataService` to `IbkrMarketDataService` in the `AppContext` to enable fetching of live historical data from Interactive Brokers. This resolves the issue where historical data requests were returning empty, as the backtest service was being used incorrectly for live data fetching.

The change also involved resolving circular dependencies between the market data service and other components like the `TickProcessor` by initializing the service with a null dependency and setting it later.